### PR TITLE
Publish @kanbn/mcp-tool package

### DIFF
--- a/packages/mcp-tool/README.md
+++ b/packages/mcp-tool/README.md
@@ -1,0 +1,19 @@
+# @kanbn/mcp-tool
+
+This package bundles Kanbn MCP tool definitions (input and output schemas).
+
+## Usage
+
+### Register tools with an MCP server
+```js
+const tools = require('@kanbn/mcp-tool');
+Object.values(tools).forEach(toolDef => server.addTool(toolDef));
+```
+
+### Use with `mcp-test`
+```yaml
+servers:
+  - name: kanbn
+    url: http://localhost:4444
+    toolsPackage: '@kanbn/mcp-tool'
+```

--- a/packages/mcp-tool/README.md
+++ b/packages/mcp-tool/README.md
@@ -6,7 +6,7 @@ This package bundles Kanbn MCP tool definitions (input and output schemas).
 
 ### Register tools with an MCP server
 ```js
-const tools = require('@kanbn/mcp-tool');
+const { tools } = require('@kanbn/mcp-tool');
 Object.values(tools).forEach(toolDef => server.addTool(toolDef));
 ```
 

--- a/packages/mcp-tool/index.js
+++ b/packages/mcp-tool/index.js
@@ -2,12 +2,28 @@ const path = require('path');
 const fs = require('fs');
 
 const toolsDir = path.join(__dirname, 'tools');
-const files = fs.readdirSync(toolsDir).filter(f => f.endsWith('.json'));
 
-const tools = files.reduce((acc, file) => {
-  const name = path.basename(file, '.json');
-  acc[name] = require(path.join(toolsDir, file));
-  return acc;
-}, {});
+// Check if tools directory exists
+if (!fs.existsSync(toolsDir)) {
+  console.warn(`Warning: tools directory not found at ${toolsDir}`);
+  module.exports = { tools: {} };
+} else {
+  try {
+    const files = fs.readdirSync(toolsDir).filter(f => f.endsWith('.json'));
+    
+    const tools = files.reduce((acc, file) => {
+      const name = path.basename(file, '.json');
+      try {
+        acc[name] = require(path.join(toolsDir, file));
+      } catch (error) {
+        console.error(`Error loading tool definition from ${file}:`, error.message);
+      }
+      return acc;
+    }, {});
 
-module.exports = { tools };
+    module.exports = { tools };
+  } catch (error) {
+    console.error(`Error reading tools directory ${toolsDir}:`, error.message);
+    module.exports = { tools: {} };
+  }
+}

--- a/packages/mcp-tool/index.js
+++ b/packages/mcp-tool/index.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const fs = require('fs');
+
+const toolsDir = path.join(__dirname, 'tools');
+const files = fs.readdirSync(toolsDir).filter(f => f.endsWith('.json'));
+
+module.exports = files.reduce((acc, file) => {
+  const name = path.basename(file, '.json');
+  acc[name] = require(path.join(toolsDir, file));
+  return acc;
+}, {});

--- a/packages/mcp-tool/index.js
+++ b/packages/mcp-tool/index.js
@@ -4,8 +4,10 @@ const fs = require('fs');
 const toolsDir = path.join(__dirname, 'tools');
 const files = fs.readdirSync(toolsDir).filter(f => f.endsWith('.json'));
 
-module.exports = files.reduce((acc, file) => {
+const tools = files.reduce((acc, file) => {
   const name = path.basename(file, '.json');
   acc[name] = require(path.join(toolsDir, file));
   return acc;
 }, {});
+
+module.exports = { tools };

--- a/packages/mcp-tool/package.json
+++ b/packages/mcp-tool/package.json
@@ -3,10 +3,14 @@
   "version": "0.1.0",
   "description": "Kanbn MCP tool definitions (input/output schemas) for MCP server & mcp-test",
   "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
   "files": [
     "tools/*.json",
     "index.js",
-    "README.md"
+    "README.md",
+    "test/"
   ],
   "keywords": ["kanbn", "mcp", "mcp-tool"],
   "author": "Tosin Akinsoho",
@@ -15,5 +19,11 @@
     "type": "git",
     "url": "https://github.com/decision-crafters/kanbn.git",
     "directory": "packages/mcp-tool"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/packages/mcp-tool/package.json
+++ b/packages/mcp-tool/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "files": [
     "tools/*.json",
+    "index.js",
     "README.md"
   ],
   "keywords": ["kanbn", "mcp", "mcp-tool"],

--- a/packages/mcp-tool/package.json
+++ b/packages/mcp-tool/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@kanbn/mcp-tool",
+  "version": "0.1.0",
+  "description": "Kanbn MCP tool definitions (input/output schemas) for MCP server & mcp-test",
+  "main": "index.js",
+  "files": [
+    "tools/*.json",
+    "README.md"
+  ],
+  "keywords": ["kanbn", "mcp", "mcp-tool"],
+  "author": "Tosin Akinsoho",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decision-crafters/kanbn.git",
+    "directory": "packages/mcp-tool"
+  }
+}

--- a/packages/mcp-tool/test/index.test.js
+++ b/packages/mcp-tool/test/index.test.js
@@ -1,5 +1,5 @@
 const QUnit = require('qunit');
-const tools = require('..');
+const { tools } = require('..');
 
 QUnit.module('@kanbn/mcp-tool');
 

--- a/packages/mcp-tool/test/index.test.js
+++ b/packages/mcp-tool/test/index.test.js
@@ -1,13 +1,45 @@
-const QUnit = require('qunit');
 const { tools } = require('..');
 
-QUnit.module('@kanbn/mcp-tool');
+describe('@kanbn/mcp-tool', () => {
+  test('exports at least one tool definition', () => {
+    const keys = Object.keys(tools);
+    expect(keys.length).toBeGreaterThan(0);
+    
+    const sample = tools[keys[0]];
+    expect(typeof sample.name).toBe('string');
+    expect(typeof sample.inputSchema).toBe('object');
+    expect(typeof sample.outputSchema).toBe('object');
+  });
 
-QUnit.test('exports at least one tool definition', assert => {
-  const keys = Object.keys(tools);
-  assert.ok(keys.length > 0, 'has at least one tool');
-  const sample = tools[keys[0]];
-  assert.equal(typeof sample.name, 'string', 'tool has name');
-  assert.equal(typeof sample.inputSchema, 'object', 'tool has inputSchema');
-  assert.equal(typeof sample.outputSchema, 'object', 'tool has outputSchema');
+  test('all tools have required properties', () => {
+    const toolKeys = Object.keys(tools);
+    
+    toolKeys.forEach(key => {
+      const tool = tools[key];
+      expect(tool).toHaveProperty('name');
+      expect(tool).toHaveProperty('inputSchema');
+      expect(tool).toHaveProperty('outputSchema');
+      expect(typeof tool.name).toBe('string');
+      expect(typeof tool.inputSchema).toBe('object');
+      expect(typeof tool.outputSchema).toBe('object');
+    });
+  });
+
+  test('kanbn_task_add tool exists and has correct structure', () => {
+    expect(tools).toHaveProperty('kanbn_task_add');
+    
+    const taskAddTool = tools.kanbn_task_add;
+    expect(taskAddTool.name).toBe('kanbn_task_add');
+    expect(taskAddTool.description).toBe('Add a task to the Kanbn board');
+    
+    // Verify input schema structure
+    expect(taskAddTool.inputSchema.type).toBe('object');
+    expect(taskAddTool.inputSchema.properties).toHaveProperty('name');
+    expect(taskAddTool.inputSchema.required).toContain('name');
+    
+    // Verify output schema structure
+    expect(taskAddTool.outputSchema.type).toBe('object');
+    expect(taskAddTool.outputSchema.properties).toHaveProperty('taskId');
+    expect(taskAddTool.outputSchema.required).toContain('taskId');
+  });
 });

--- a/packages/mcp-tool/test/index.test.js
+++ b/packages/mcp-tool/test/index.test.js
@@ -1,0 +1,13 @@
+const QUnit = require('qunit');
+const tools = require('..');
+
+QUnit.module('@kanbn/mcp-tool');
+
+QUnit.test('exports at least one tool definition', assert => {
+  const keys = Object.keys(tools);
+  assert.ok(keys.length > 0, 'has at least one tool');
+  const sample = tools[keys[0]];
+  assert.equal(typeof sample.name, 'string', 'tool has name');
+  assert.equal(typeof sample.inputSchema, 'object', 'tool has inputSchema');
+  assert.equal(typeof sample.outputSchema, 'object', 'tool has outputSchema');
+});

--- a/packages/mcp-tool/tools/kanbn_task_add.json
+++ b/packages/mcp-tool/tools/kanbn_task_add.json
@@ -1,0 +1,20 @@
+{
+  "name": "kanbn_task_add",
+  "description": "Add a task to the Kanbn board",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "name": {"type": "string"},
+      "description": {"type": "string"},
+      "column": {"type": "string"}
+    },
+    "required": ["name"]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "taskId": {"type": "string"}
+    },
+    "required": ["taskId"]
+  }
+}


### PR DESCRIPTION
Closes #128

Adds new `@kanbn/mcp-tool` package containing MCP tool definitions. Includes a simple loader, README, sample tool JSON, and smoke test.

------
https://chatgpt.com/codex/tasks/task_e_684ca83b98208327b81df830c9c0ecc2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the @kanbn/mcp-tool package, providing Kanbn MCP tool definitions with input and output schemas.
  - Added a tool for adding tasks to a Kanbn board, including schema definitions for inputs and outputs.

- **Documentation**
  - Added a comprehensive README with usage instructions and configuration guidance.

- **Tests**
  - Implemented initial tests to verify the structure and presence of tool definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->