### PR TITLE
Document jest migration process

### DIFF
--- a/qunit-to-jest-migration-issue.md
+++ b/qunit-to-jest-migration-issue.md
@@ -1,0 +1,16 @@
+# QUnit to Jest Migration Issue
+
+This document tracks the ongoing effort to migrate all QUnit based tests to Jest.
+
+## Phase 1 Priority Files
+- `test/unit/main.test.js`
+- `test/unit/create.test.js`
+- `test/unit/move.test.js`
+- `test/unit/task-utils.test.js`
+- `test/unit/file-utils.test.js`
+- `test/unit/initialise.test.js`
+- `test/unit/rename.test.js`
+
+Each file should be migrated independently so that debugging and reviews remain focused. Once a file is converted and verified under Jest, open a pull request referencing this document and the related issue.
+
+See `JEST_MIGRATION_GUIDE.md` for general migration tips.

--- a/test/unit/main.test.js
+++ b/test/unit/main.test.js
@@ -1,45 +1,44 @@
 // test/unit/main.test.js
-const QUnit = require('qunit');
 const mockRequire = require('mock-require');
 let findTaskColumn, taskCompleted, sortTasks, renameTaskInIndex;
 
-QUnit.module('main wrapper tests', {
-  before: () => {
+describe('main wrapper tests', () => {
+  beforeAll(() => {
     // Stub task-utils
-    mockRequire('../../src/lib/task-utils', {
+    mockRequire(require.resolve('../../src/lib/task-utils'), {
       findTaskColumn: (idx, id) => 'stub-col',
       taskCompleted: (idx, task) => true,
       renameTaskInIndex: (idx, id, newId) => 'renamed-id'
     });
     // Stub index-utils
-    mockRequire('../../src/lib/index-utils', {
+    mockRequire(require.resolve('../../src/lib/index-utils'), {
       sortTasks: (tasks, sorters) => ['stub-task']
     });
     // Import wrappers after stubbing
     ({ findTaskColumn, taskCompleted, sortTasks, renameTaskInIndex } = require('../../src/main'));
-  },
-  after: () => {
+  });
+  afterAll(() => {
     // Remove all mocks
     mockRequire.stopAll();
-  }
-});
+  });
 
-QUnit.test('findTaskColumn should delegate to task-utils', assert => {
-  const result = findTaskColumn({ columns: {} }, 'task-1');
-  assert.equal(result, 'stub-col', 'Wrapper returns stubbed column');
-});
+  test('findTaskColumn should delegate to task-utils', () => {
+    const result = findTaskColumn({ columns: {} }, 'task-1');
+    expect(result).toBe('stub-col');
+  });
 
-QUnit.test('taskCompleted should delegate to task-utils', assert => {
-  const result = taskCompleted({}, { id: 'task-2' });
-  assert.equal(result, true, 'Wrapper returns stubbed completion');
-});
+  test('taskCompleted should delegate to task-utils', () => {
+    const result = taskCompleted({}, { id: 'task-2' });
+    expect(result).toBe(true);
+  });
 
-QUnit.test('sortTasks should delegate to index-utils', assert => {
-  const result = sortTasks([], [{ field: 'id' }]);
-  assert.deepEqual(result, ['stub-task'], 'Wrapper returns stubbed sorted list');
-});
+  test('sortTasks should delegate to index-utils', () => {
+    const result = sortTasks([], [{ field: 'id' }]);
+    expect(result).toEqual(['stub-task']);
+  });
 
-QUnit.test('renameTaskInIndex should delegate to task-utils', assert => {
-  const result = renameTaskInIndex({ columns: {} }, 'old-id', 'new-id');
-  assert.equal(result, 'renamed-id', 'Wrapper returns stubbed renamed ID');
+  test('renameTaskInIndex should delegate to task-utils', () => {
+    const result = renameTaskInIndex({ columns: {} }, 'old-id', 'new-id');
+    expect(result).toBe('renamed-id');
+  });
 });


### PR DESCRIPTION
## Summary
- add plan for QUnit-to-Jest migration
- convert `main.test.js` from QUnit to Jest
- fix mock paths in `main.test.js`

@coderabbit review

QUnit to Jest Migration: Systematic Test File Conversion
Problem Statement
Currently 64 test files use QUnit syntax and need systematic conversion to Jest. Only 1 test file has been successfully migrated so far.

Proposed Solution
Create separate issues for each problematic test file to enable:

Focused debugging per test
Parallel development
Risk isolation
Clear progress tracking
Phase 1 Priority Tests (High Impact)

test/unit/main.test.js - Core functionality

test/unit/create.test.js - Task creation

test/unit/move.test.js - Task movement

test/unit/task-utils.test.js - Task utilities

test/unit/file-utils.test.js - File operations

test/unit/initialise.test.js - Initialization

test/unit/rename.test.js - Known issues with index file access
Technical Requirements
Maintain existing test logic and assertions
Preserve test isolation and cleanup
Update async/await patterns where needed
Ensure mock/stub functionality works with Jest
Acceptance Criteria

All migrated tests pass with Jest

Test coverage remains the same or improves

No QUnit dependencies remain

CI/CD pipeline runs successfully
Related Documentation
Migration guide: qunit-to-jest-migration-issue.md
Jest config: jest.config.js

------
https://chatgpt.com/codex/tasks/task_e_684d931dbb348327ab885452c54d173f