### PR TITLE
Convert sprint unit test to Jest

### DIFF
--- a/test/unit/sprint.test.js
+++ b/test/unit/sprint.test.js
@@ -1,81 +1,76 @@
 const mockFileSystem = require('mock-fs');
 const kanbn = require('../../src/main');
-const context = require('../context');
+const context = require('../context-jest');
 
-QUnit.module('sprint tests', {
-  before() {
-    require('../qunit-throws-async');
-  },
-  beforeEach() {
+describe('sprint tests', () => {
+  beforeEach(() => {
     mockFileSystem();
-  },
-  afterEach() {
+  });
+
+  afterEach(() => {
     mockFileSystem.restore();
-  }
-});
-
-QUnit.test('Start a sprint in uninitialised folder should throw "not initialised" error', async assert => {
-  assert.throwsAsync(
-    async () => {
-      await kanbn.sprint('Sprint 1', '', new Date());
-    },
-    /Not initialised in this folder/
-  );
-});
-
-QUnit.test('Start a sprint should create a new sprint', async assert => {
-  const SPRINT_NAME = 'Test Sprint';
-  const SPRINT_DESCRIPTION = 'Test description...';
-  const SPRINT_DATE = new Date();
-  await kanbn.initialise();
-
-  // Start a sprint
-  await kanbn.sprint(SPRINT_NAME, SPRINT_DESCRIPTION, SPRINT_DATE);
-
-  // Verify that the sprint exists
-  context.indexHasOptions(assert, await kanbn.getMainFolder(), {
-    sprints: [
-      {
-        name: SPRINT_NAME,
-        description: SPRINT_DESCRIPTION,
-        start: SPRINT_DATE
-      }
-    ]
-  });
-});
-
-QUnit.test('Start a sprint with auto-generated name', async assert => {
-  const BASE_PATH = await kanbn.getMainFolder();
-  const SPRINT_DATE = new Date();
-  await kanbn.initialise();
-
-  // Start a sprint without a name or description
-  await kanbn.sprint('', '', SPRINT_DATE);
-
-  // Verify that the sprint exists
-  context.indexHasOptions(assert, BASE_PATH, {
-    sprints: [
-      {
-        name: 'Sprint 1',
-        start: SPRINT_DATE
-      }
-    ]
   });
 
-  // Start another sprint
-  await kanbn.sprint('', '', SPRINT_DATE);
+  test('Start a sprint in uninitialised folder should throw "not initialised" error', async () => {
+    await expect(
+      kanbn.sprint('Sprint 1', '', new Date())
+    ).rejects.toThrow(/Not initialised in this folder/);
+  });
 
-  // Verify that the new sprint exists
-  context.indexHasOptions(assert, BASE_PATH, {
-    sprints: [
-      {
-        name: 'Sprint 1',
-        start: SPRINT_DATE
-      },
-      {
-        name: 'Sprint 2',
-        start: SPRINT_DATE
-      }
-    ]
+  test('Start a sprint should create a new sprint', async () => {
+    const SPRINT_NAME = 'Test Sprint';
+    const SPRINT_DESCRIPTION = 'Test description...';
+    const SPRINT_DATE = new Date();
+    await kanbn.initialise();
+
+    // Start a sprint
+    await kanbn.sprint(SPRINT_NAME, SPRINT_DESCRIPTION, SPRINT_DATE);
+
+    // Verify that the sprint exists
+    context.indexHasOptions(await kanbn.getMainFolder(), {
+      sprints: [
+        {
+          name: SPRINT_NAME,
+          description: SPRINT_DESCRIPTION,
+          start: SPRINT_DATE
+        }
+      ]
+    });
+  });
+
+  test('Start a sprint with auto-generated name', async () => {
+    const BASE_PATH = await kanbn.getMainFolder();
+    const SPRINT_DATE = new Date();
+    await kanbn.initialise();
+
+    // Start a sprint without a name or description
+    await kanbn.sprint('', '', SPRINT_DATE);
+
+    // Verify that the sprint exists
+    context.indexHasOptions(BASE_PATH, {
+      sprints: [
+        {
+          name: 'Sprint 1',
+          start: SPRINT_DATE
+        }
+      ]
+    });
+
+    // Start another sprint
+    await kanbn.sprint('', '', SPRINT_DATE);
+
+    // Verify that the new sprint exists
+    context.indexHasOptions(BASE_PATH, {
+      sprints: [
+        {
+          name: 'Sprint 1',
+          start: SPRINT_DATE
+        },
+        {
+          name: 'Sprint 2',
+          start: SPRINT_DATE
+        }
+      ]
+    });
   });
 });


### PR DESCRIPTION
## Summary
- migrate `test/unit/sprint.test.js` from QUnit to Jest

## Testing
- `npm test` *(fails: Cannot find module 'qunit' and other dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871eb170ca08327ab27115fc6ec0a81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Migrated sprint functionality tests from QUnit to Jest for improved consistency and maintainability. Test scenarios and expectations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->