### PR TITLE
Add tests for custom errors

### DIFF
--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -1,0 +1,40 @@
+const KanbnError = require('../../src/errors/KanbnError');
+const {
+  AiError,
+  ProviderUnavailableError,
+  RateLimitError,
+  ServiceError,
+  normaliseAiError
+} = require('../../src/errors/AiError');
+
+describe('custom error classes', () => {
+  test('KanbnError stores message and context', () => {
+    const err = new KanbnError('oops', { code: 'E_TEST', detail: 42 });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('KanbnError');
+    expect(err.message).toBe('oops');
+    expect(err.context).toEqual({ code: 'E_TEST', detail: 42 });
+  });
+
+  test('AiError subclasses retain name and message', () => {
+    const err = new ProviderUnavailableError('down');
+    expect(err).toBeInstanceOf(AiError);
+    expect(err.name).toBe('ProviderUnavailableError');
+    expect(err.message).toBe('down');
+  });
+
+  test('normaliseAiError maps rate limit messages', () => {
+    const e = normaliseAiError(new Error('Rate limit exceeded'));
+    expect(e).toBeInstanceOf(RateLimitError);
+  });
+
+  test('normaliseAiError maps connectivity messages', () => {
+    const e = normaliseAiError(new Error('Connection refused'));
+    expect(e).toBeInstanceOf(ProviderUnavailableError);
+  });
+
+  test('normaliseAiError defaults to ServiceError', () => {
+    const e = normaliseAiError(new Error('Something else'));
+    expect(e).toBeInstanceOf(ServiceError);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest unit tests for `KanbnError` and AI error hierarchy

## Testing
- `npx jest test/unit/errors.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6871f075aa008327b95b93e923668c71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests to verify correct behavior of custom error classes and error normalization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->